### PR TITLE
Runtime support for -profile=gc

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,5 +2,5 @@ FROM ubuntu
 COPY *.sh ./
 RUN ./base.sh
 RUN ./dmd.sh 2.071.2-0
-RUN ./dmd1.sh v1.078.0
+RUN ./dmd1.sh v1.080.0
 RUN rm *.sh

--- a/pkg/libtangort-dmd-dev.pkg
+++ b/pkg/libtangort-dmd-dev.pkg
@@ -6,7 +6,7 @@ OPTS = dict(
     maintainer = 'Leandro Lucarella <leandro.lucarella@sociomantic.com>',
     vendor = 'Sociomantic Labs GmbH',
     license = 'BSD-2-clause',
-    depends = 'dmd1', # TODO: get dmd1 dependency from metadata file
+    depends = 'dmd1 >= 1.080.0', # TODO: get dmd1 dependency from metadata file
     deb_recommends = 'dmd1-rt',
     provides = ['dmd1-rt', 'libtango1-dev', 'libtango1-dmd-dev'],
     replaces = 'libtango1-dmd-dev',

--- a/src/rt/profilegc.d
+++ b/src/rt/profilegc.d
@@ -1,0 +1,133 @@
+/*
+ * Data collection and report generation for
+ *   -profile=gc
+ * switch
+ *
+ * Copyright: Copyright Digital Mars 2015 - 2015.
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
+ * Authors:   Andrei Alexandrescu and Walter Bright
+ * Source: $(DRUNTIMESRC src/rt/_profilegc.d)
+ */
+
+module rt.profilegc;
+
+private:
+
+import core.stdc.stdio;
+import core.stdc.stdlib;
+import core.stdc.string;
+
+import core.exception : onOutOfMemoryError;
+
+struct Entry { size_t count, size; }
+
+char[] buffer;
+Entry[char[]] newCounts;
+char[] logfilename = "profilegc.log";
+
+/****
+ * Set file name for output.
+ * A file name of "" means write results to stdout.
+ * Params:
+ *      name = file name
+ */
+
+extern (C) void profilegc_setlogfilename(char[] name)
+{
+    logfilename = name;
+}
+
+
+
+public void accumulate(char[] file, uint line, char[] funcname, char[] type, size_t sz)
+{
+    char[3 * line.sizeof + 1] buf;
+    auto buflen = snprintf(buf.ptr, buf.length, "%u".ptr, line);
+
+    auto lngth = type.length + 1 + funcname.length + 1 + file.length + 1 + buflen;
+    if (lngth > buffer.length)
+    {
+        // Enlarge buffer[] so it is big enough
+        auto p = cast(char*)realloc(buffer.ptr, lngth);
+        if (!p)
+            onOutOfMemoryError();
+        buffer = p[0 .. lngth];
+    }
+
+    // "type funcname file:line"
+    buffer[0 .. type.length] = type[];
+    buffer[type.length] = ' ';
+    buffer[type.length + 1 ..
+           type.length + 1 + funcname.length] = funcname[];
+    buffer[type.length + 1 + funcname.length] = ' ';
+    buffer[type.length + 1 + funcname.length + 1 ..
+           type.length + 1 + funcname.length + 1 + file.length] = file[];
+    buffer[type.length + 1 + funcname.length + 1 + file.length] = ':';
+    buffer[type.length + 1 + funcname.length + 1 + file.length + 1 ..
+           type.length + 1 + funcname.length + 1 + file.length + 1 + buflen] = buf[0 .. buflen];
+
+    if (auto pcount = cast(char[])buffer[0 .. lngth] in newCounts)
+    { // existing entry
+        pcount.count++;
+        pcount.size += sz;
+    }
+    else
+        newCounts[buffer[0..lngth].dup] = Entry(1, sz); // new entry
+}
+
+// Write report to stderr
+static ~this()
+{
+    static struct Result
+    {
+        char[] name;
+        Entry entry;
+
+        // qsort() comparator to sort by count field
+        extern (C) static int qsort_cmp(in void *r1, in void *r2)
+        {
+            auto result1 = cast(Result*)r1;
+            auto result2 = cast(Result*)r2;
+            ptrdiff_t cmp = result2.entry.size - result1.entry.size;
+            if (cmp) return cmp < 0 ? -1 : 1;
+            cmp = result2.entry.count - result1.entry.count;
+            return cmp < 0 ? -1 : (cmp > 0 ? 1 : 0);
+        }
+    }
+
+    Result[] counts = new Result[newCounts.length];
+
+    size_t i;
+    foreach (name, entry; newCounts)
+    {
+        counts[i].name = name;
+        counts[i].entry = entry;
+        ++i;
+    }
+
+    if (counts.length)
+    {
+        qsort(counts.ptr, counts.length, Result.sizeof, &Result.qsort_cmp);
+
+        FILE* fp = logfilename.length == 0 ? stdout : fopen((logfilename ~
+            '\0').ptr, "w".ptr);
+        if (fp)
+        {
+            fprintf(fp,
+                "bytes allocated, allocations, type, function, file:line\n".ptr);
+            foreach (ref c; counts)
+            {
+                fprintf(fp, "%15llu\t%15llu\t%8.*s\n".ptr,
+                    cast(ulong)c.entry.size, cast(ulong)c.entry.count,
+                    c.name.length, c.name.ptr);
+            }
+            if (logfilename.length)
+                fclose(fp);
+        }
+        else
+            fprintf(stderr, "cannot write profilegc log file '%.*s'".ptr,
+                logfilename.length, logfilename.ptr);
+    }
+}

--- a/src/rt/tracegc.d
+++ b/src/rt/tracegc.d
@@ -1,0 +1,459 @@
+/**
+ * Contains implementations of functions called when the
+ *   -profile=gc
+ * switch is thrown.
+ *
+ * Copyright: Copyright Digital Mars 2015 - 2015.
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
+ * Authors:   Walter Bright
+ * Source: $(DRUNTIMESRC src/rt/_tracegc.d)
+ */
+
+module rt.tracegc;
+
+//version = tracegc;
+
+import rt.profilegc;
+
+version (tracegc) import core.stdc.stdio;
+
+version (none)
+{
+    // this exercises each function
+
+    struct S { ~this() { } }
+    class C { }
+    interface I { }
+
+    void main()
+    {
+      {
+        auto a = new C();
+        auto b = new int;
+        auto c = new int[3];
+        auto d = new int[][](3,4);
+        auto e = new float;
+        auto f = new float[3];
+        auto g = new float[][](3,4);
+      }
+        printf("\n");
+      {
+        int[] a; delete a;
+        S[] as; delete as;
+        C c; delete c;
+        I i; delete i;
+        C* pc = &c; delete *pc;
+        I* pi = &i; delete *pi;
+        int* pint; delete pint;
+        S* ps; delete ps;
+      }
+        printf("\n");
+      {
+        int[] a = [1, 2, 3];
+        char[][int] aa = [1:"one", 2:"two", 3:"three"];
+      }
+        printf("\n");
+      {
+        int[] a, b, c;
+        c = a ~ b;
+        c = a ~ b ~ c;
+      }
+        printf("\n");
+      {
+        dchar dc = 'a';
+        char[] ac; ac ~= dc;
+        wchar[] aw; aw ~= dc;
+        char[] ac2; ac2 ~= ac;
+        int[] ai; ai ~= 3;
+      }
+        printf("\n");
+      {
+        int[] ai; ai.length = 10;
+        float[] af; af.length = 10;
+      }
+        printf("\n");
+        int v;
+      {
+        int foo() { return v; }
+        static int delegate() dg;
+        dg = &foo;      // dynamic closure
+      }
+    }
+}
+
+extern (C) Object _d_newclass(in ClassInfo ci);
+extern (C) void[] _d_newarrayT(in TypeInfo ti, size_t length);
+extern (C) void[] _d_newarrayiT(in TypeInfo ti, size_t length);
+extern (C) void[] _d_newarraymTX(in TypeInfo ti, size_t[] dims);
+extern (C) void[] _d_newarraymiTX(in TypeInfo ti, size_t[] dims);
+
+extern (C) Object _d_newclassTrace(char[] file, int line, char[] funcname, in ClassInfo ci)
+{
+    version (tracegc)
+    {
+        printf("_d_newclassTrace class = %s file = '%.*s' line = %d function = '%.*s'\n",
+            cast(char *)ci.name,
+            file.length, file.ptr,
+            line,
+            funcname.length, funcname.ptr
+            );
+    }
+    accumulate(file, line, funcname, ci.name, ci.init.length);
+    return _d_newclass(ci);
+}
+
+extern (C) void[] _d_newarrayTTrace(char[] file, int line, char[] funcname, in TypeInfo ti, size_t length)
+{
+    version (tracegc)
+    {
+        printf("_d_newarrayTTrace type = %s length = %llu file = '%.*s' line = %d function = '%.*s'\n",
+            cast(char *)ti.toString().ptr,
+            cast(ulong)length,
+            file.length, file.ptr,
+            line,
+            funcname.length, funcname.ptr
+            );
+    }
+    accumulate(file, line, funcname, ti.toString(), ti.tsize * length);
+    return _d_newarrayT(ti, length);
+}
+
+extern (C) void[] _d_newarrayiTTrace(char[] file, int line, char[] funcname, in TypeInfo ti, size_t length)
+{
+    version (tracegc)
+    {
+        printf("_d_newarrayiTTrace type = %s length = %llu file = '%.*s' line = %d function = '%.*s'\n",
+            cast(char *)ti.toString().ptr,
+            cast(ulong)length,
+            file.length, file.ptr,
+            line,
+            funcname.length, funcname.ptr
+            );
+    }
+    accumulate(file, line, funcname, ti.toString(), ti.tsize * length);
+    return _d_newarrayiT(ti, length);
+}
+
+extern (C) void[] _d_newarraymTXTrace(char[] file, int line, char[] funcname, in TypeInfo ti, size_t[] dims)
+{
+    version (tracegc)
+    {
+        printf("_d_newarraymTXTrace type = %s dims = %llu file = '%.*s' line = %d function = '%.*s'\n",
+            cast(char *)ti.toString().ptr,
+            cast(ulong)dims.length,
+            file.length, file.ptr,
+            line,
+            funcname.length, funcname.ptr
+            );
+    }
+    size_t n = 1;
+    foreach (dim; dims)
+        n *= dim;
+    accumulate(file, line, funcname, ti.toString(), ti.tsize * n);
+    return _d_newarraymTX(ti, dims);
+}
+
+extern (C) void[] _d_newarraymiTXTrace(char[] file, int line, char[] funcname,
+    in TypeInfo ti, size_t[] dims)
+{
+    version (tracegc)
+    {
+        printf("_d_newarraymiTXTrace type = %s dims = %llu file = '%.*s' line = %d function = '%.*s'\n",
+            cast(char *)ti.toString().ptr,
+            cast(ulong)dims.length,
+            file.length, file.ptr,
+            line,
+            funcname.length, funcname.ptr
+            );
+    }
+    size_t n = 1;
+    foreach (dim; dims)
+        n *= dim;
+    accumulate(file, line, funcname, ti.toString(), ti.tsize * n);
+    return _d_newarraymiTX(ti, dims);
+}
+
+extern (C) void _d_callfinalizer(void* p);
+extern (C) void _d_callinterfacefinalizer(void *p);
+extern (C) void _d_delclass(Object* p);
+extern (C) void _d_delinterface(void** p);
+extern (C) void _d_delmemory(void* *p);
+
+extern (C) void _d_callfinalizerTrace(char[] file, int line, char[] funcname, void* p)
+{
+    version (tracegc)
+    {
+        printf("_d_callfinalizerTrace %p file = '%.*s' line = %d function = '%.*s'\n",
+            p,
+            file.length, file.ptr,
+            line,
+            funcname.length, funcname.ptr
+            );
+    }
+    _d_callfinalizer(p);
+}
+
+extern (C) void _d_callinterfacefinalizerTrace(char[] file, int line, char[] funcname, void *p)
+{
+    version (tracegc)
+    {
+        printf("_d_callinterfacefinalizerTrace %p file = '%.*s' line = %d function = '%.*s'\n",
+            p,
+            file.length, file.ptr,
+            line,
+            funcname.length, funcname.ptr
+            );
+    }
+    _d_callinterfacefinalizer(p);
+}
+
+extern (C) void _d_delclassTrace(char[] file, int line, char[] funcname, Object* p)
+{
+    version (tracegc)
+    {
+        printf("_d_delclassTrace %p file = '%.*s' line = %d function = '%.*s'\n",
+            *p,
+            file.length, file.ptr,
+            line,
+            funcname.length, funcname.ptr
+            );
+    }
+    _d_delclass(p);
+}
+
+extern (C) void _d_delinterfaceTrace(char[] file, int line, char[] funcname, void** p)
+{
+    version (tracegc)
+    {
+        printf("_d_delinterfaceTrace %p file = '%.*s' line = %d function = '%.*s'\n",
+            *p,
+            file.length, file.ptr,
+            line,
+            funcname.length, funcname.ptr
+            );
+    }
+    _d_delinterface(p);
+}
+
+extern (C) void _d_delmemoryTrace(char[] file, int line, char[] funcname, void* *p)
+{
+    version (tracegc)
+    {
+        printf("_d_delmemoryTrace %p file = '%.*s' line = %d function = '%.*s'\n",
+            *p,
+            file.length, file.ptr,
+            line,
+            funcname.length, funcname.ptr
+            );
+    }
+    _d_delmemory(p);
+}
+
+
+extern (C) void* _d_arrayliteralTX(in TypeInfo ti, size_t length);
+extern (C) void* _d_assocarrayliteralTX(in TypeInfo_AssociativeArray ti,
+    void[] keys, void[] vals);
+
+extern (C) void* _d_arrayliteralTXTrace(char[] file, int line, char[] funcname,
+    in TypeInfo ti, size_t length)
+{
+    version (tracegc)
+    {
+        printf("_d_arrayliteralTXTrace type = %s length = %llu file = '%.*s' line = %d function = '%.*s'\n",
+            cast(char *)ti.toString().ptr,
+            cast(ulong)length,
+            file.length, file.ptr,
+            line,
+            funcname.length, funcname.ptr
+            );
+    }
+    accumulate(file, line, funcname, ti.toString(), ti.next.tsize * length);
+    return _d_arrayliteralTX(ti, length);
+}
+
+extern (C) void* _d_assocarrayliteralTXTrace(char[] file, int line, char[] funcname,
+        in TypeInfo_AssociativeArray ti, void[] keys, void[] vals)
+{
+    version (tracegc)
+    {
+        printf("_d_assocarrayliteralTXTrace type = %s keys = %llu values = %llu file = '%.*s' line = %d function = '%.*s'\n",
+            cast(char *)ti.toString().ptr,
+            cast(ulong)keys.length,
+            cast(ulong)vals.length,
+            file.length, file.ptr,
+            line,
+            funcname.length, funcname.ptr
+            );
+    }
+    accumulate(file, line, funcname, ti.toString(), (ti.key.tsize + ti.value.tsize) * keys.length);
+    return _d_assocarrayliteralTX(ti, keys, vals);
+}
+
+
+
+extern (C) byte[] _d_arraycatT(in TypeInfo ti, byte[] x, byte[] y);
+extern (C) void[] _d_arraycatnTX(in TypeInfo ti, byte[][] arrs);
+
+extern (C) byte[] _d_arraycatTTrace(char[] file, int line, char[] funcname,
+    in TypeInfo ti, byte[] x, byte[] y)
+{
+    version (tracegc)
+    {
+        printf("_d_arraycatT type = %s x = %llu y = %llu file = '%.*s' line = %d function = '%.*s'\n",
+            cast(char *)ti.toString().ptr,
+            cast(ulong)x.length,
+            cast(ulong)y.length,
+            file.length, file.ptr,
+            line,
+            funcname.length, funcname.ptr
+            );
+    }
+    accumulate(file, line, funcname, ti.toString(), (x.length + y.length) * ti.next.tsize);
+    return _d_arraycatT(ti, x, y);
+}
+
+extern (C) void[] _d_arraycatnTXTrace(char[] file, int line, char[] funcname,
+    in TypeInfo ti, byte[][] arrs)
+{
+    version (tracegc)
+    {
+        printf("_d_arraycatnTX type = %s arrs = %llu file = '%.*s' line = %d function = '%.*s'\n",
+            cast(char *)ti.toString().ptr,
+            cast(ulong)arrs.length,
+            file.length, file.ptr,
+            line,
+            funcname.length, funcname.ptr
+            );
+    }
+    size_t length;
+    foreach (b; arrs)
+        length += b.length;
+    accumulate(file, line, funcname, ti.toString(), length * ti.next.tsize);
+    return _d_arraycatnTX(ti, arrs);
+}
+
+extern (C) void[] _d_arrayappendT(in TypeInfo ti, ref byte[] x, byte[] y);
+extern (C) byte[] _d_arrayappendcTX(in TypeInfo ti, ref byte[] px, size_t n);
+extern (C) void[] _d_arrayappendcd(ref byte[] x, dchar c);
+extern (C) void[] _d_arrayappendwd(ref byte[] x, dchar c);
+
+extern (C) void[] _d_arrayappendTTrace(char[] file, int line, char[] funcname,
+    in TypeInfo ti, ref byte[] x, byte[] y)
+{
+    version (tracegc)
+    {
+        printf("_d_arrayappendT type = %s x = %llu y = %llu file = '%.*s' line = %d function = '%.*s'\n",
+            cast(char *)ti.toString().ptr,
+            cast(ulong)x.length,
+            cast(ulong)y.length,
+            file.length, file.ptr,
+            line,
+            funcname.length, funcname.ptr
+            );
+    }
+    accumulate(file, line, funcname, ti.toString(), ti.next.tsize * y.length);
+    return _d_arrayappendT(ti, x, y);
+}
+
+extern (C) byte[] _d_arrayappendcTXTrace(char[] file, int line, char[] funcname,
+    in TypeInfo ti, ref byte[] px, size_t n)
+{
+    version (tracegc)
+    {
+        printf("_d_arrayappendcTX type = %s x = %llu n = %llu file = '%.*s' line = %d function = '%.*s'\n",
+            cast(char *)ti.toString().ptr,
+            cast(ulong)px.length,
+            cast(ulong)n,
+            file.length, file.ptr,
+            line,
+            funcname.length, funcname.ptr
+            );
+    }
+    accumulate(file, line, funcname, ti.toString(), ti.next.tsize * n);
+    return _d_arrayappendcTX(ti, px, n);
+}
+
+extern (C) void[] _d_arrayappendcdTrace(char[] file, int line, char[] funcname, ref byte[] x, dchar c)
+{
+    version (tracegc)
+    {
+        printf("_d_arrayappendcd x = %llu c = x%x file = '%.*s' line = %d function = '%.*s'\n",
+            cast(ulong)x.length,
+            c,
+            file.length, file.ptr,
+            line,
+            funcname.length, funcname.ptr
+            );
+    }
+    size_t n;
+    if (c <= 0x7F)
+        n = 1;
+    else if (c <= 0x7FF)
+        n = 2;
+    else if (c <= 0xFFFF)
+        n = 3;
+    else if (c <= 0x10FFFF)
+        n = 4;
+    else
+        assert(0);
+    accumulate(file, line, funcname, "char[]", n * char.sizeof);
+    return _d_arrayappendcd(x, c);
+}
+
+extern (C) void[] _d_arrayappendwdTrace(char[] file, int line, char[] funcname, ref byte[] x, dchar c)
+{
+    version (tracegc)
+    {
+        printf("_d_arrayappendwd x = %llu c = x%x file = '%.*s' line = %d function = '%.*s'\n",
+            cast(ulong)x.length,
+            c,
+            file.length, file.ptr,
+            line,
+            funcname.length, funcname.ptr
+            );
+    }
+    size_t n = 1 + (c > 0xFFFF);
+    accumulate(file, line, funcname, "wchar[]", n * wchar.sizeof);
+    return _d_arrayappendwd(x, c);
+}
+
+extern (C) void[] _d_arraysetlengthT(in TypeInfo ti, size_t newlength, void[]* p);
+extern (C) void[] _d_arraysetlengthiT(in TypeInfo ti, size_t newlength, void[]* p);
+
+extern (C) void[] _d_arraysetlengthTTrace(char[] file, int line,
+    char[] funcname, in TypeInfo ti, size_t newlength, void[]* p)
+{
+    version (tracegc)
+    {
+        printf("_d_arraysetlengthT type = %s length = %llu newlength = %llu file = '%.*s' line = %d function = '%.*s'\n",
+            cast(char *)ti.toString().ptr,
+            cast(ulong)(*p).length,
+            cast(ulong)newlength,
+            file.length, file.ptr,
+            line,
+            funcname.length, funcname.ptr
+            );
+    }
+    accumulate(file, line, funcname, ti.toString(), ti.next.tsize * newlength);
+    return _d_arraysetlengthT(ti, newlength, p);
+}
+
+extern (C) void[] _d_arraysetlengthiTTrace(char[] file, int line,
+    char[] funcname, in TypeInfo ti, size_t newlength, void[]* p)
+{
+    version (tracegc)
+    {
+        printf("_d_arraysetlengthiT type = %s length = %llu newlength = %llu file = '%.*s' line = %d function = '%.*s'\n",
+            cast(char *)ti.toString().ptr,
+            cast(ulong)(*p).length,
+            cast(ulong)newlength,
+            file.length, file.ptr,
+            line,
+            funcname.length, funcname.ptr
+            );
+    }
+    accumulate(file, line, funcname, ti.toString(), ti.next.tsize * newlength);
+    return _d_arraysetlengthiT(ti, newlength, p);
+}

--- a/src/rt/tracegc.d
+++ b/src/rt/tracegc.d
@@ -13,141 +13,50 @@
 
 module rt.tracegc;
 
-//version = tracegc;
-
 import rt.profilegc;
-
-version (tracegc) import core.stdc.stdio;
-
-version (none)
-{
-    // this exercises each function
-
-    struct S { ~this() { } }
-    class C { }
-    interface I { }
-
-    void main()
-    {
-      {
-        auto a = new C();
-        auto b = new int;
-        auto c = new int[3];
-        auto d = new int[][](3,4);
-        auto e = new float;
-        auto f = new float[3];
-        auto g = new float[][](3,4);
-      }
-        printf("\n");
-      {
-        int[] a; delete a;
-        S[] as; delete as;
-        C c; delete c;
-        I i; delete i;
-        C* pc = &c; delete *pc;
-        I* pi = &i; delete *pi;
-        int* pint; delete pint;
-        S* ps; delete ps;
-      }
-        printf("\n");
-      {
-        int[] a = [1, 2, 3];
-        char[][int] aa = [1:"one", 2:"two", 3:"three"];
-      }
-        printf("\n");
-      {
-        int[] a, b, c;
-        c = a ~ b;
-        c = a ~ b ~ c;
-      }
-        printf("\n");
-      {
-        dchar dc = 'a';
-        char[] ac; ac ~= dc;
-        wchar[] aw; aw ~= dc;
-        char[] ac2; ac2 ~= ac;
-        int[] ai; ai ~= 3;
-      }
-        printf("\n");
-      {
-        int[] ai; ai.length = 10;
-        float[] af; af.length = 10;
-      }
-        printf("\n");
-        int v;
-      {
-        int foo() { return v; }
-        static int delegate() dg;
-        dg = &foo;      // dynamic closure
-      }
-    }
-}
 
 extern (C) Object _d_newclass(in ClassInfo ci);
 extern (C) void[] _d_newarrayT(in TypeInfo ti, size_t length);
 extern (C) void[] _d_newarrayiT(in TypeInfo ti, size_t length);
 extern (C) void[] _d_newarraymTX(in TypeInfo ti, size_t[] dims);
 extern (C) void[] _d_newarraymiTX(in TypeInfo ti, size_t[] dims);
+extern (C) void _d_callfinalizer(void* p);
+extern (C) void _d_callinterfacefinalizer(void *p);
+extern (C) void _d_delclass(Object* p);
+extern (C) void _d_delinterface(void** p);
+extern (C) void _d_delmemory(void* *p);
+extern (C) void* _d_arrayliteralTX(in TypeInfo ti, size_t length);
+extern (C) void* _d_assocarrayliteralTX(in TypeInfo_AssociativeArray ti,
+    void[] keys, void[] vals);
+extern (C) byte[] _d_arraycatT(in TypeInfo ti, byte[] x, byte[] y);
+extern (C) void[] _d_arraycatnTX(in TypeInfo ti, byte[][] arrs);
+extern (C) void[] _d_arrayappendT(in TypeInfo ti, ref byte[] x, byte[] y);
+extern (C) byte[] _d_arrayappendcTX(in TypeInfo ti, ref byte[] px, size_t n);
+extern (C) void[] _d_arrayappendcd(ref byte[] x, dchar c);
+extern (C) void[] _d_arrayappendwd(ref byte[] x, dchar c);
+extern (C) void[] _d_arraysetlengthT(in TypeInfo ti, size_t newlength, void[]* p);
+extern (C) void[] _d_arraysetlengthiT(in TypeInfo ti, size_t newlength, void[]* p);
 
 extern (C) Object _d_newclassTrace(char[] file, int line, char[] funcname, in ClassInfo ci)
 {
-    version (tracegc)
-    {
-        printf("_d_newclassTrace class = %s file = '%.*s' line = %d function = '%.*s'\n",
-            cast(char *)ci.name,
-            file.length, file.ptr,
-            line,
-            funcname.length, funcname.ptr
-            );
-    }
     accumulate(file, line, funcname, ci.name, ci.init.length);
     return _d_newclass(ci);
 }
 
 extern (C) void[] _d_newarrayTTrace(char[] file, int line, char[] funcname, in TypeInfo ti, size_t length)
 {
-    version (tracegc)
-    {
-        printf("_d_newarrayTTrace type = %s length = %llu file = '%.*s' line = %d function = '%.*s'\n",
-            cast(char *)ti.toString().ptr,
-            cast(ulong)length,
-            file.length, file.ptr,
-            line,
-            funcname.length, funcname.ptr
-            );
-    }
     accumulate(file, line, funcname, ti.toString(), ti.tsize * length);
     return _d_newarrayT(ti, length);
 }
 
 extern (C) void[] _d_newarrayiTTrace(char[] file, int line, char[] funcname, in TypeInfo ti, size_t length)
 {
-    version (tracegc)
-    {
-        printf("_d_newarrayiTTrace type = %s length = %llu file = '%.*s' line = %d function = '%.*s'\n",
-            cast(char *)ti.toString().ptr,
-            cast(ulong)length,
-            file.length, file.ptr,
-            line,
-            funcname.length, funcname.ptr
-            );
-    }
     accumulate(file, line, funcname, ti.toString(), ti.tsize * length);
     return _d_newarrayiT(ti, length);
 }
 
 extern (C) void[] _d_newarraymTXTrace(char[] file, int line, char[] funcname, in TypeInfo ti, size_t[] dims)
 {
-    version (tracegc)
-    {
-        printf("_d_newarraymTXTrace type = %s dims = %llu file = '%.*s' line = %d function = '%.*s'\n",
-            cast(char *)ti.toString().ptr,
-            cast(ulong)dims.length,
-            file.length, file.ptr,
-            line,
-            funcname.length, funcname.ptr
-            );
-    }
     size_t n = 1;
     foreach (dim; dims)
         n *= dim;
@@ -158,16 +67,6 @@ extern (C) void[] _d_newarraymTXTrace(char[] file, int line, char[] funcname, in
 extern (C) void[] _d_newarraymiTXTrace(char[] file, int line, char[] funcname,
     in TypeInfo ti, size_t[] dims)
 {
-    version (tracegc)
-    {
-        printf("_d_newarraymiTXTrace type = %s dims = %llu file = '%.*s' line = %d function = '%.*s'\n",
-            cast(char *)ti.toString().ptr,
-            cast(ulong)dims.length,
-            file.length, file.ptr,
-            line,
-            funcname.length, funcname.ptr
-            );
-    }
     size_t n = 1;
     foreach (dim; dims)
         n *= dim;
@@ -175,100 +74,34 @@ extern (C) void[] _d_newarraymiTXTrace(char[] file, int line, char[] funcname,
     return _d_newarraymiTX(ti, dims);
 }
 
-extern (C) void _d_callfinalizer(void* p);
-extern (C) void _d_callinterfacefinalizer(void *p);
-extern (C) void _d_delclass(Object* p);
-extern (C) void _d_delinterface(void** p);
-extern (C) void _d_delmemory(void* *p);
-
 extern (C) void _d_callfinalizerTrace(char[] file, int line, char[] funcname, void* p)
 {
-    version (tracegc)
-    {
-        printf("_d_callfinalizerTrace %p file = '%.*s' line = %d function = '%.*s'\n",
-            p,
-            file.length, file.ptr,
-            line,
-            funcname.length, funcname.ptr
-            );
-    }
     _d_callfinalizer(p);
 }
 
 extern (C) void _d_callinterfacefinalizerTrace(char[] file, int line, char[] funcname, void *p)
 {
-    version (tracegc)
-    {
-        printf("_d_callinterfacefinalizerTrace %p file = '%.*s' line = %d function = '%.*s'\n",
-            p,
-            file.length, file.ptr,
-            line,
-            funcname.length, funcname.ptr
-            );
-    }
     _d_callinterfacefinalizer(p);
 }
 
 extern (C) void _d_delclassTrace(char[] file, int line, char[] funcname, Object* p)
 {
-    version (tracegc)
-    {
-        printf("_d_delclassTrace %p file = '%.*s' line = %d function = '%.*s'\n",
-            *p,
-            file.length, file.ptr,
-            line,
-            funcname.length, funcname.ptr
-            );
-    }
     _d_delclass(p);
 }
 
 extern (C) void _d_delinterfaceTrace(char[] file, int line, char[] funcname, void** p)
 {
-    version (tracegc)
-    {
-        printf("_d_delinterfaceTrace %p file = '%.*s' line = %d function = '%.*s'\n",
-            *p,
-            file.length, file.ptr,
-            line,
-            funcname.length, funcname.ptr
-            );
-    }
     _d_delinterface(p);
 }
 
 extern (C) void _d_delmemoryTrace(char[] file, int line, char[] funcname, void* *p)
 {
-    version (tracegc)
-    {
-        printf("_d_delmemoryTrace %p file = '%.*s' line = %d function = '%.*s'\n",
-            *p,
-            file.length, file.ptr,
-            line,
-            funcname.length, funcname.ptr
-            );
-    }
     _d_delmemory(p);
 }
-
-
-extern (C) void* _d_arrayliteralTX(in TypeInfo ti, size_t length);
-extern (C) void* _d_assocarrayliteralTX(in TypeInfo_AssociativeArray ti,
-    void[] keys, void[] vals);
 
 extern (C) void* _d_arrayliteralTXTrace(char[] file, int line, char[] funcname,
     in TypeInfo ti, size_t length)
 {
-    version (tracegc)
-    {
-        printf("_d_arrayliteralTXTrace type = %s length = %llu file = '%.*s' line = %d function = '%.*s'\n",
-            cast(char *)ti.toString().ptr,
-            cast(ulong)length,
-            file.length, file.ptr,
-            line,
-            funcname.length, funcname.ptr
-            );
-    }
     accumulate(file, line, funcname, ti.toString(), ti.next.tsize * length);
     return _d_arrayliteralTX(ti, length);
 }
@@ -276,40 +109,13 @@ extern (C) void* _d_arrayliteralTXTrace(char[] file, int line, char[] funcname,
 extern (C) void* _d_assocarrayliteralTXTrace(char[] file, int line, char[] funcname,
         in TypeInfo_AssociativeArray ti, void[] keys, void[] vals)
 {
-    version (tracegc)
-    {
-        printf("_d_assocarrayliteralTXTrace type = %s keys = %llu values = %llu file = '%.*s' line = %d function = '%.*s'\n",
-            cast(char *)ti.toString().ptr,
-            cast(ulong)keys.length,
-            cast(ulong)vals.length,
-            file.length, file.ptr,
-            line,
-            funcname.length, funcname.ptr
-            );
-    }
     accumulate(file, line, funcname, ti.toString(), (ti.key.tsize + ti.value.tsize) * keys.length);
     return _d_assocarrayliteralTX(ti, keys, vals);
 }
 
-
-
-extern (C) byte[] _d_arraycatT(in TypeInfo ti, byte[] x, byte[] y);
-extern (C) void[] _d_arraycatnTX(in TypeInfo ti, byte[][] arrs);
-
 extern (C) byte[] _d_arraycatTTrace(char[] file, int line, char[] funcname,
     in TypeInfo ti, byte[] x, byte[] y)
 {
-    version (tracegc)
-    {
-        printf("_d_arraycatT type = %s x = %llu y = %llu file = '%.*s' line = %d function = '%.*s'\n",
-            cast(char *)ti.toString().ptr,
-            cast(ulong)x.length,
-            cast(ulong)y.length,
-            file.length, file.ptr,
-            line,
-            funcname.length, funcname.ptr
-            );
-    }
     accumulate(file, line, funcname, ti.toString(), (x.length + y.length) * ti.next.tsize);
     return _d_arraycatT(ti, x, y);
 }
@@ -317,16 +123,6 @@ extern (C) byte[] _d_arraycatTTrace(char[] file, int line, char[] funcname,
 extern (C) void[] _d_arraycatnTXTrace(char[] file, int line, char[] funcname,
     in TypeInfo ti, byte[][] arrs)
 {
-    version (tracegc)
-    {
-        printf("_d_arraycatnTX type = %s arrs = %llu file = '%.*s' line = %d function = '%.*s'\n",
-            cast(char *)ti.toString().ptr,
-            cast(ulong)arrs.length,
-            file.length, file.ptr,
-            line,
-            funcname.length, funcname.ptr
-            );
-    }
     size_t length;
     foreach (b; arrs)
         length += b.length;
@@ -334,25 +130,9 @@ extern (C) void[] _d_arraycatnTXTrace(char[] file, int line, char[] funcname,
     return _d_arraycatnTX(ti, arrs);
 }
 
-extern (C) void[] _d_arrayappendT(in TypeInfo ti, ref byte[] x, byte[] y);
-extern (C) byte[] _d_arrayappendcTX(in TypeInfo ti, ref byte[] px, size_t n);
-extern (C) void[] _d_arrayappendcd(ref byte[] x, dchar c);
-extern (C) void[] _d_arrayappendwd(ref byte[] x, dchar c);
-
 extern (C) void[] _d_arrayappendTTrace(char[] file, int line, char[] funcname,
     in TypeInfo ti, ref byte[] x, byte[] y)
 {
-    version (tracegc)
-    {
-        printf("_d_arrayappendT type = %s x = %llu y = %llu file = '%.*s' line = %d function = '%.*s'\n",
-            cast(char *)ti.toString().ptr,
-            cast(ulong)x.length,
-            cast(ulong)y.length,
-            file.length, file.ptr,
-            line,
-            funcname.length, funcname.ptr
-            );
-    }
     accumulate(file, line, funcname, ti.toString(), ti.next.tsize * y.length);
     return _d_arrayappendT(ti, x, y);
 }
@@ -360,33 +140,12 @@ extern (C) void[] _d_arrayappendTTrace(char[] file, int line, char[] funcname,
 extern (C) byte[] _d_arrayappendcTXTrace(char[] file, int line, char[] funcname,
     in TypeInfo ti, ref byte[] px, size_t n)
 {
-    version (tracegc)
-    {
-        printf("_d_arrayappendcTX type = %s x = %llu n = %llu file = '%.*s' line = %d function = '%.*s'\n",
-            cast(char *)ti.toString().ptr,
-            cast(ulong)px.length,
-            cast(ulong)n,
-            file.length, file.ptr,
-            line,
-            funcname.length, funcname.ptr
-            );
-    }
     accumulate(file, line, funcname, ti.toString(), ti.next.tsize * n);
     return _d_arrayappendcTX(ti, px, n);
 }
 
 extern (C) void[] _d_arrayappendcdTrace(char[] file, int line, char[] funcname, ref byte[] x, dchar c)
 {
-    version (tracegc)
-    {
-        printf("_d_arrayappendcd x = %llu c = x%x file = '%.*s' line = %d function = '%.*s'\n",
-            cast(ulong)x.length,
-            c,
-            file.length, file.ptr,
-            line,
-            funcname.length, funcname.ptr
-            );
-    }
     size_t n;
     if (c <= 0x7F)
         n = 1;
@@ -404,38 +163,14 @@ extern (C) void[] _d_arrayappendcdTrace(char[] file, int line, char[] funcname, 
 
 extern (C) void[] _d_arrayappendwdTrace(char[] file, int line, char[] funcname, ref byte[] x, dchar c)
 {
-    version (tracegc)
-    {
-        printf("_d_arrayappendwd x = %llu c = x%x file = '%.*s' line = %d function = '%.*s'\n",
-            cast(ulong)x.length,
-            c,
-            file.length, file.ptr,
-            line,
-            funcname.length, funcname.ptr
-            );
-    }
     size_t n = 1 + (c > 0xFFFF);
     accumulate(file, line, funcname, "wchar[]", n * wchar.sizeof);
     return _d_arrayappendwd(x, c);
 }
 
-extern (C) void[] _d_arraysetlengthT(in TypeInfo ti, size_t newlength, void[]* p);
-extern (C) void[] _d_arraysetlengthiT(in TypeInfo ti, size_t newlength, void[]* p);
-
 extern (C) void[] _d_arraysetlengthTTrace(char[] file, int line,
     char[] funcname, in TypeInfo ti, size_t newlength, void[]* p)
 {
-    version (tracegc)
-    {
-        printf("_d_arraysetlengthT type = %s length = %llu newlength = %llu file = '%.*s' line = %d function = '%.*s'\n",
-            cast(char *)ti.toString().ptr,
-            cast(ulong)(*p).length,
-            cast(ulong)newlength,
-            file.length, file.ptr,
-            line,
-            funcname.length, funcname.ptr
-            );
-    }
     accumulate(file, line, funcname, ti.toString(), ti.next.tsize * newlength);
     return _d_arraysetlengthT(ti, newlength, p);
 }
@@ -443,17 +178,6 @@ extern (C) void[] _d_arraysetlengthTTrace(char[] file, int line,
 extern (C) void[] _d_arraysetlengthiTTrace(char[] file, int line,
     char[] funcname, in TypeInfo ti, size_t newlength, void[]* p)
 {
-    version (tracegc)
-    {
-        printf("_d_arraysetlengthiT type = %s length = %llu newlength = %llu file = '%.*s' line = %d function = '%.*s'\n",
-            cast(char *)ti.toString().ptr,
-            cast(ulong)(*p).length,
-            cast(ulong)newlength,
-            file.length, file.ptr,
-            line,
-            funcname.length, funcname.ptr
-            );
-    }
     accumulate(file, line, funcname, ti.toString(), ti.next.tsize * newlength);
     return _d_arraysetlengthiT(ti, newlength, p);
 }


### PR DESCRIPTION
This is runtime part of backporting of `-profile=gc` switch to D1. It can be merged/deployed before matching compiler version for smoother transition - it doesn't modify existing functionality and only defines new `extern(C)` functions.

Relevant modules are copied and adapted from D2 runtime. Main change
compared to original version is that multi-threading support is removed as it
was relying on TLS to work.

In absence of compiler support, one can play with runtime hooks by calling them manually. For example, this code:

```D
// sample.d
extern (C) void[] _d_newarrayTTrace(char[] file, int line, char[] funcname, in
	TypeInfo ti, size_t length);

void main ( )
{
	_d_newarrayTTrace(__FILE__, __LINE__, "main", typeid(int[]), 10);
}
```

will generate this `profilegc.log` : 
```
bytes allocated, allocations, type, function, file:line
            160	              1	int[] main ./sample.d:6
```