### PR TITLE
Upgrade makd to 1.9.0

### DIFF
--- a/docker/dmd1.sh
+++ b/docker/dmd1.sh
@@ -24,7 +24,7 @@ export VERSION=$(git describe --dirty | cut -c2- |
 make -C src -f posix.mak
 
 # Make package using MakD
-git clone -b v1.7.x --single-branch --depth 50 \
+git clone -b v1.9.0 --single-branch --depth 50 \
         https://github.com/sociomantic-tsunami/makd.git
 
 mkdir -p pkg


### PR DESCRIPTION
Fixes failing travis builds (tries to checkout missing 1.7.x)

```
* makd v1.7.3(c6c6e40)...v1.9.0(0661a59) (24 commits)
  > Deprecate FUN.mapbins in favour of FUN.mapfiles
  > mkpkg: Add new function FUN.mapfiles
  > Merge tag 'v1.8.3' into v1.x.x
  > mkpkg: Add FUN.desc()
  > Fix typo
  (...)
```