### PR TITLE
Make writev(2) const compatible

### DIFF
--- a/src/core/sys/posix/sys/uio.d
+++ b/src/core/sys/posix/sys/uio.d
@@ -36,23 +36,32 @@ struct iovec
     size_t iov_len;
 }
 
+version (D_Version2)
+    struct iovec_const
+    {
+        mixin("const(void)* iov_base;");
+        size_t iov_len;
+    }
+else
+    alias iovec iovec_const;
+
 version( linux )
 {
     ssize_t readv(int, in iovec*, int);
-    ssize_t writev(int, in iovec*, int);
+    ssize_t writev(int, in iovec_const*, int);
 }
 else version( darwin )
 {
     ssize_t readv(int, in iovec*, int);
-    ssize_t writev(int, in iovec*, int);
+    ssize_t writev(int, in iovec_const*, int);
 }
 else version( freebsd )
 {
     ssize_t readv(int, in iovec*, int);
-    ssize_t writev(int, in iovec*, int);
+    ssize_t writev(int, in iovec_const*, int);
 }
 else version( solaris )
 {
     ssize_t readv(int, in iovec*, int);
-    ssize_t writev(int, in iovec*, int);
+    ssize_t writev(int, in iovec_const*, int);
 }

--- a/src/core/sys/posix/sys/uio.d
+++ b/src/core/sys/posix/sys/uio.d
@@ -30,47 +30,29 @@ ssize_t readv(int, in iovec*, int);
 ssize_t writev(int, in iovec*, int);
 */
 
+struct iovec
+{
+    void* iov_base;
+    size_t iov_len;
+}
+
 version( linux )
 {
-    struct iovec
-    {
-        void*  iov_base;
-        size_t iov_len;
-    }
-
     ssize_t readv(int, in iovec*, int);
     ssize_t writev(int, in iovec*, int);
 }
 else version( darwin )
 {
-    struct iovec
-    {
-        void*  iov_base;
-        size_t iov_len;
-    }
-
     ssize_t readv(int, in iovec*, int);
     ssize_t writev(int, in iovec*, int);
 }
 else version( freebsd )
 {
-    struct iovec
-    {
-        void*  iov_base;
-        size_t iov_len;
-    }
-
     ssize_t readv(int, in iovec*, int);
     ssize_t writev(int, in iovec*, int);
 }
 else version( solaris )
 {
-    struct iovec
-    {
-        void*  iov_base;
-        size_t iov_len;
-    }
-
     ssize_t readv(int, in iovec*, int);
     ssize_t writev(int, in iovec*, int);
 }


### PR DESCRIPTION
POSIX [`writev(2)`](http://pubs.opengroup.org/onlinepubs/9699919799/functions/writev.html) was not designed with D2 in mind. It is impossible to pass `const(void)[]` data to it. Fix this by adding `iovec_const` a, `const`-compatible [`iovec`](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_uio.h.html) clone.