### PR TITLE
Make coverage options configurable via env vars

### DIFF
--- a/relnotes/cov-merge.feature.md
+++ b/relnotes/cov-merge.feature.md
@@ -1,0 +1,7 @@
+## Coverage merging works without pre-existing files
+
+The code coverage option to merge reports didn't do anything before if no
+pre-existing reports were found. There is no good reason for this behaviour, and
+makes it more complicated to do multiple runs, as one must know which will have
+to happen first to pass the merge option conditionally, so it's better to just
+create new reports if they don't exist while merging.

--- a/relnotes/cov-opts.feature.md
+++ b/relnotes/cov-opts.feature.md
@@ -1,0 +1,7 @@
+## Configure coverage via environment variables
+
+Now some coverage options can be set via environment variables:
+
+* `DRT_COVMERGE`: Merge current results with pre-existing coverage reports.
+* `DRT_COVSRCPATH`: Set path to where source files are located.
+* `DRT_COVDSTPATH`: Set path to where listing files are to be written.

--- a/src/rt/cover.d
+++ b/src/rt/cover.d
@@ -157,10 +157,9 @@ static ~this()
             continue;
         splitLines( srcbuf, srclines );
 
-        if( merge )
+        if( merge &&
+                readFile( addExt( baseName( c.filename ), "lst" ), lstbuf ) )
         {
-            if( !readFile( addExt( baseName( c.filename ), "lst" ), lstbuf ) )
-                break;
             splitLines( lstbuf, lstlines );
 
             for( size_t i = 0; i < lstlines.length; ++i )


### PR DESCRIPTION
Now some coverage options can be set via environment variables:

* `DRT_COVMERGE`: Merge current results with pre-existing coverage reports.
* `DRT_COVSRCPATH`: Set path to where source files are located.
* `DRT_COVDSTPATH`: Set path to where listing files are to be written.