### PR TITLE
Remove Trusty support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ env:
         # Make sure beaver is in the PATH
         - PATH="$(git config -f .gitmodules submodule.beaver.path)/bin:$PATH"
     matrix:
-        - DIST=trusty
         - DIST=xenial
 
 install: beaver install

--- a/Dockerfile.trusty
+++ b/Dockerfile.trusty
@@ -1,3 +1,0 @@
-FROM sociomantictsunami/dlang:trusty-v2-test
-COPY docker/ /docker-tmp
-RUN /docker-tmp/build && rm -fr /docker-tmp


### PR DESCRIPTION
Remove trusty support from all projects. Trusty is already more than 3 years old and the latest LTS (Xenial) has already been out there for more than a year, so it should be enough to maintain the latest LTS only now.