### PR TITLE
Call _Exit(3) instead of exit(3) in the child process

### DIFF
--- a/src/gc/cdgc/gc.d
+++ b/src/gc/cdgc/gc.d
@@ -947,7 +947,7 @@ size_t fullcollect(void *stackTop, bool early = false, bool force_block = false)
             break;
         case 0: // child process (i.e. the collectors mark phase)
             mark(stackTop);
-            cstdlib.exit(0);
+            cstdlib._Exit(0);
             break; // bogus, will never reach here
         default: // parent process (i.e. the mutator)
             thread_resumeAll();


### PR DESCRIPTION
From `man 3 _Exit`:

The function _Exit is like exit(3), but does not call any functions
registered with atexit(3) or on_exit(3). Open stdio(3) streams are not
flushed.

```

Other than that, _Exit closes all the file descriptors, sends SIGCHLD
signal to the parent. Since we _don't want_ to run any atexit handlers
(especially as they might try to run destructors) or flush anything,
we call _Exit(3) instead.