### PR TITLE
Provide `core.exception.onRangeError`

### DIFF
--- a/relnotes/onrange.feature.md
+++ b/relnotes/onrange.feature.md
@@ -1,0 +1,5 @@
+# D2 compatible `onRangeError` definition
+
+New `extern(C)` function was added to `core.exception` module - `onRangeError`.
+it simply calls existing `onArrayBoundsError` function. It was added to make API
+more compatible with D2 runtime which doesn't have `onArrayBoundsError`.

--- a/src/core/exception.d
+++ b/src/core/exception.d
@@ -216,6 +216,13 @@ extern (C) void onArrayBoundsError( char[] file, size_t line )
     throw new RangeError( file, cast(long)line );
 }
 
+/**
+ * Compatibility with D2 runtime
+ */
+extern (C) void onRangeError( char[] file, size_t line )
+{
+    onArrayBoundsError(file, line);
+}
 
 /**
  * A callback for finalize errors in D.  A FinalizeError will be thrown.


### PR DESCRIPTION
See https://github.com/sociomantic-tsunami/dmqnode/pull/5/commits/47a179a052116a19719db399e924ceef050adbdd