### PR TITLE
travis: Build the package before uploading

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,5 +32,7 @@ jobs:
           if: tag IS present
           # env: before_install: and install: are inherited and we don't need
           # to override them.
-          script: beaver bintray upload -d sociomantic-tsunami/dlang/tangort
-                  build/last/pkg/*.deb
+          script:
+              - beaver dlang make pkg
+              - beaver bintray upload -d sociomantic-tsunami/dlang/tangort
+                build/last/pkg/*.deb


### PR DESCRIPTION
Since Travis stages share nothing, we need to rebuild the package before
uploading it.