### PR TITLE
Add ClassInfo.initializer to object.di

### DIFF
--- a/src/rt/include/object.di
+++ b/src/rt/include/object.di
@@ -77,6 +77,7 @@ struct PointerMapBuilder
 class ClassInfo : Object
 {
     byte[]      init;   // class static initializer
+    byte[] initializer ( );
     char[]      name;   /// class name
     void*[]     vtbl;   // virtual function pointer table
     Interface[] interfaces; /// implemented interfaces


### PR DESCRIPTION
This method was added to object_.d and it should be present
in the accompanying di file.