### PR TITLE
Reimplement tracegc to use actual gc stats

### DIFF
--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -55,7 +55,7 @@ private
     alias extern(D) void delegate(int, int) dint;
 
     extern (C) void gc_monitor(ddel begin, dint end );
-    extern (C) void gc_usage(size_t* used, size_t* free);
+    extern (C) void gc_usage(size_t* used, size_t* free, size_t* last);
 }
 
 
@@ -570,6 +570,7 @@ struct GC
      */
     static void usage ( out size_t used, out size_t free )
     {
-        return gc_usage(&used, &free);
+        size_t unused;
+        return gc_usage(&used, &free, &unused);
     }
 }


### PR DESCRIPTION
Matches logic currently implemented in our dmd-transitional patch.

(replacement for https://github.com/sociomantic-tsunami/tangort/pull/12 from my current account :))